### PR TITLE
Upgrade base image to 26.04, update node image tags, and pin npm for Node 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         include:
           - IMAGE_NAME: node
-            IMAGE_TAG: 22-24.04
+            IMAGE_TAG: 22-26.04
           - IMAGE_NAME: node
-            IMAGE_TAG: 24-24.04
+            IMAGE_TAG: 24-26.04
     steps:
       - uses: actions/checkout@v4
       - name: docker build
@@ -44,9 +44,9 @@ jobs:
       matrix:
         include:
           - IMAGE_NAME: node
-            IMAGE_TAG: 22-24.04
+            IMAGE_TAG: 22-26.04
           - IMAGE_NAME: node
-            IMAGE_TAG: 24-24.04
+            IMAGE_TAG: 24-26.04
     steps:
       - name: docker push
         uses: kubasejdak-org/docker-push-action@main

--- a/node/22-26.04/Dockerfile
+++ b/node/22-26.04/Dockerfile
@@ -1,15 +1,15 @@
-FROM kubasejdak/base:24.04
+FROM kubasejdak/base:26.04
 
 # Settings.
 ARG NODE_VERSION=22
 ARG NVMSH_VERSION=0.40.4
 
-# Install node and latest npm.
+# Install node and npm.
 RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVMSH_VERSION}/install.sh | bash && \
     export NVM_DIR="${HOME}/.nvm" && \
     . ${NVM_DIR}/nvm.sh && \
     nvm install ${NODE_VERSION} && \
-    npm install -g npm@latest && \
+    npm install -g npm@11.11.0 && \
     npm config -g set fund false && \
     \
     # Cleanup image.

--- a/node/24-26.04/Dockerfile
+++ b/node/24-26.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM kubasejdak/base:24.04
+FROM kubasejdak/base:26.04
 
 # Settings.
 ARG NODE_VERSION=24


### PR DESCRIPTION
### Motivation
- Move Node images to the newer base `26.04` and reflect that in image tags and Dockerfile locations to keep base OS up to date.
- Ensure reproducible npm behavior for the Node 22 image by pinning a specific `npm` version.

### Description
- Updated the GitHub Actions workflow `/.github/workflows/build.yml` to build and deploy image tags `22-26.04` and `24-26.04` instead of the `*-24.04` tags.
- Renamed Dockerfile folders from `node/22-24.04` -> `node/22-26.04` and `node/24-24.04` -> `node/24-26.04`.
- Changed the Dockerfiles to use `FROM kubasejdak/base:26.04` instead of `:24.04`.
- Pinned `npm` to `npm@11.11.0` in the Node 22 Dockerfile while keeping the Node 24 Dockerfile using `npm@latest`.

### Testing
- No automated tests were executed as part of this change; the CI workflow was updated but not run in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6de05f8c8326a29a4d538470da8e)